### PR TITLE
Unitialized 'old_cnt' varible was causing a runtime error inside the execute function.

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -2297,6 +2297,7 @@ class BakeConstrainedActions(bpy.types.Operator):
         if not self.do_bake:
             return {'FINISHED'}
 
+        old_cnt = 0
         sel_obs = list(context.selected_objects)
         for ob in sel_obs:
             if bpy.app.version < (2, 80):


### PR DESCRIPTION
When baking constrained actions, a runtime error was causing a fully successful bake to abort. This happens when list(bpy.data.actions) is empty.